### PR TITLE
hotfix: mejorar CTAs de Amazon (CRO)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,13 @@
 <html lang="es">
 
 <head>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9670469054020650" crossorigin="anonymous"></script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9670469054020650"
+    crossorigin="anonymous"></script>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-B06YM5N4P8"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
+    function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
 
     gtag('config', 'G-B06YM5N4P8');
@@ -178,7 +179,7 @@
         </div>
         <ul class="main-nav">
           <li><a href="/" class="nav-link">Inicio</a></li>
-          
+
           <li><a href="/blog/" class="nav-link">Blog</a></li>
 
           <li class="nav-item-has-children">
@@ -251,7 +252,7 @@
                 <td>Silla Oficina / Coche</td>
                 <td>⭐⭐⭐⭐⭐ (4.5)</td>
                 <td><a href="https://amzn.to/4rq0TCE" class="cta-small" target="_blank"
-                    rel="nofollow sponsored noopener">Ver Precio</a></td>
+                    rel="nofollow sponsored noopener">Ver Oferta</a></td>
               </tr>
               <tr>
                 <td>
@@ -264,7 +265,7 @@
                 <td>Jornadas Largas</td>
                 <td>⭐⭐⭐⭐☆ (4.3)</td>
                 <td><a href="https://amzn.to/4rzBWOd" class="cta-small" target="_blank"
-                    rel="nofollow sponsored noopener">Ver Precio</a></td>
+                    rel="nofollow sponsored noopener">Ver Oferta</a></td>
               </tr>
               <tr>
                 <td>
@@ -277,7 +278,7 @@
                 <td>Postura Correcta</td>
                 <td>⭐⭐⭐⭐☆ (4.4)</td>
                 <td><a href="https://amzn.to/4c2mRXA" class="cta-small" target="_blank"
-                    rel="nofollow sponsored noopener">Ver Precio</a></td>
+                    rel="nofollow sponsored noopener">Ver Oferta</a></td>
               </tr>
             </tbody>
           </table>
@@ -327,7 +328,7 @@
           <div class="product-cta">
             <a href="https://amzn.to/4rq0TCE" class="cta-button" target="_blank" rel="nofollow sponsored noopener"
               aria-label="Ver precio de Feagar en Amazon">Ver
-              precio en Amazon →</a>
+              oferta en Amazon →</a>
           </div>
         </div>
 
@@ -348,7 +349,7 @@
           <div class="product-cta">
             <a href="https://amzn.to/4rzBWOd" class="cta-button" target="_blank" rel="nofollow sponsored noopener"
               aria-label="Ver precio de Cojín Ergonómico en Amazon">Ver
-              precio en Amazon →</a>
+              oferta en Amazon →</a>
           </div>
         </div>
 
@@ -369,7 +370,7 @@
           <div class="product-cta">
             <a href="https://amzn.to/4c2mRXA" class="cta-button" target="_blank" rel="nofollow sponsored noopener"
               aria-label="Ver precio de Fortem en Amazon">Ver
-              precio en Amazon →</a>
+              oferta en Amazon →</a>
           </div>
         </div>
       </div>

--- a/mejor-cojin-coxis-teletrabajo/index.html
+++ b/mejor-cojin-coxis-teletrabajo/index.html
@@ -2,12 +2,13 @@
 <html lang="es">
 
 <head>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9670469054020650" crossorigin="anonymous"></script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9670469054020650"
+    crossorigin="anonymous"></script>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-B06YM5N4P8"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
+    function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
 
     gtag('config', 'G-B06YM5N4P8');
@@ -80,7 +81,7 @@
         </div>
         <ul class="main-nav">
           <li><a href="/" class="nav-link">Inicio</a></li>
-          
+
           <li><a href="/blog/" class="nav-link">Blog</a></li>
 
           <li class="nav-item-has-children">
@@ -160,7 +161,7 @@
             <li>Buena estabilidad en silla de oficina y hogar</li>
           </ul>
           <a href="https://amzn.to/4rmUkk2" class="product-rank-cta" target="_blank"
-            rel="nofollow sponsored noopener">Ver precio en Amazon →</a>
+            rel="nofollow sponsored noopener">Ver oferta en Amazon →</a>
           <p class="product-rank-note">Precio y disponibilidad pueden variar.</p>
         </div>
       </div>
@@ -187,7 +188,7 @@
             <li>Buen equilibrio entre tacto y soporte</li>
           </ul>
           <a href="https://amzn.to/4rhYVEd" class="product-rank-cta" target="_blank"
-            rel="nofollow sponsored noopener">Ver precio en Amazon →</a>
+            rel="nofollow sponsored noopener">Ver oferta en Amazon →</a>
           <p class="product-rank-note">Precio y disponibilidad pueden variar.</p>
         </div>
       </div>
@@ -214,7 +215,7 @@
             <li>Incluye bolsa de transporte y videoguías</li>
           </ul>
           <a href="https://amzn.to/467nafW" class="product-rank-cta" target="_blank"
-            rel="nofollow sponsored noopener">Ver precio en Amazon →</a>
+            rel="nofollow sponsored noopener">Ver oferta en Amazon →</a>
           <p class="product-rank-note">Precio y disponibilidad pueden variar.</p>
         </div>
       </div>
@@ -241,7 +242,7 @@
             <li>Gran confort durante periodos largos</li>
           </ul>
           <a href="https://amzn.to/4kKifHM" class="product-rank-cta" target="_blank"
-            rel="nofollow sponsored noopener">Ver precio en Amazon →</a>
+            rel="nofollow sponsored noopener">Ver oferta en Amazon →</a>
           <p class="product-rank-note">Precio y disponibilidad pueden variar.</p>
         </div>
       </div>
@@ -268,7 +269,7 @@
             <li>Funda lavable a máquina</li>
           </ul>
           <a href="https://amzn.to/4cFolXI" class="product-rank-cta" target="_blank"
-            rel="nofollow sponsored noopener">Ver precio en Amazon →</a>
+            rel="nofollow sponsored noopener">Ver oferta en Amazon →</a>
           <p class="product-rank-note">Precio y disponibilidad pueden variar.</p>
         </div>
       </div>
@@ -315,7 +316,7 @@
               <td class="table-price"><span class="price-update" data-asin="B0F1VD176V">33,99 €</span></td>
               <td>Jornadas largas con presión en coxis</td>
               <td><a href="https://amzn.to/4rmUkk2" class="table-cta" target="_blank"
-                  rel="nofollow sponsored noopener">Ver precio →</a></td>
+                  rel="nofollow sponsored noopener">Ver oferta →</a></td>
             </tr>
             <tr>
               <td><strong>Feagar Espuma Memoria</strong></td>
@@ -324,7 +325,7 @@
               <td class="table-price"><span class="price-update" data-asin="B077G7D73D">37,99 €</span></td>
               <td>Portabilidad oficina/coche/gaming</td>
               <td><a href="https://amzn.to/4rhYVEd" class="table-cta" target="_blank"
-                  rel="nofollow sponsored noopener">Ver precio →</a></td>
+                  rel="nofollow sponsored noopener">Ver oferta →</a></td>
             </tr>
             <tr>
               <td><strong>Cojín Coxis con Bolsa</strong></td>
@@ -333,7 +334,7 @@
               <td class="table-price"><span class="price-update" data-asin="B01N5LH26Y">27,90 €</span></td>
               <td>Mejor relación calidad-precio</td>
               <td><a href="https://amzn.to/467nafW" class="table-cta" target="_blank"
-                  rel="nofollow sponsored noopener">Ver precio →</a></td>
+                  rel="nofollow sponsored noopener">Ver oferta →</a></td>
             </tr>
             <tr>
               <td><strong>Cojín Premium Gel</strong></td>
@@ -342,7 +343,7 @@
               <td class="table-price"><span class="price-update" data-asin="B0DQVKH892">35,90 €</span></td>
               <td>Usuarios con calor al sentarse</td>
               <td><a href="https://amzn.to/4kKifHM" class="table-cta" target="_blank"
-                  rel="nofollow sponsored noopener">Ver precio →</a></td>
+                  rel="nofollow sponsored noopener">Ver oferta →</a></td>
             </tr>
             <tr>
               <td><strong>FORTEM Forma U</strong></td>
@@ -351,7 +352,7 @@
               <td class="table-price"><span class="price-update" data-asin="B07BDFP7NZ">25,99 €</span></td>
               <td>Soporte firme prolongado</td>
               <td><a href="https://amzn.to/4cFolXI" class="table-cta" target="_blank"
-                  rel="nofollow sponsored noopener">Ver precio →</a></td>
+                  rel="nofollow sponsored noopener">Ver oferta →</a></td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## 🚀 Descripción del Hotfix (CRO Amazon CTAs)

Este PR implementa cambios urgentes orientados a **Optimization Rate (CRO)** en los Call To Action (CTA) de los productos de Amazon, con el objetivo de acelerar nuestras 3 primeras ventas para desbloquear el PA API.

### 📝 Resumen de cambios
- **Sustitución de textos de fricción**: Se ha reemplazado la palabra *"precio"* por *"oferta"*, la cual tiene una connotación mucho más atractiva y genera un sentido de urgencia/oportunidad.
- Impacto directo en los siguientes botones:
  - [index.html](cci:7://file:///Users/carlos/GITHUB/descansointeligente.github.io/index.html:0:0-0:0) (Home): "Ver Precio" ➔ "Ver Oferta"
  - [index.html](cci:7://file:///Users/carlos/GITHUB/descansointeligente.github.io/index.html:0:0-0:0) (Home): "Ver precio en Amazon →" ➔ "Ver oferta en Amazon →"
  - [mejor-cojin-coxis-teletrabajo/index.html](cci:7://file:///Users/carlos/GITHUB/descansointeligente.github.io/mejor-cojin-coxis-teletrabajo/index.html:0:0-0:0) (Guía top): "Ver precio en Amazon →" ➔ "Ver oferta en Amazon →" y "Ver precio →" ➔ "Ver oferta →" en las tablas.

### 🎯 Objetivo principal
El objetivo es aumentar drásticamente el CTR (Click-Through Rate) hacia Amazon reduciendo la fricción psicológica de "comprar", de modo que podamos atrapar cookies de referidos en los usuarios activos actuales y acercarnos rápidamente a las 3 ventas mínimas en los primeros 180 días de nuestro perfil de afiliados.

### 🧪 Pruebas realizadas
- Verificado el correcto funcionamiento del etiquetado y que las URL de Amazon siguen siendo correctas.
- Comprobada visualmente la maquetación para asegurar que el cambio de texto no desborda los botones.
